### PR TITLE
Add noAuthCache option to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ var client = new Client({
     cwd: '/path to your svn working directory',
     username: 'username', // optional if authentication not required or is already saved
     password: 'password', // optional if authentication not required or is already saved
+    noAuthCache: true, // optional, if true, username does not become the logged in user on the machine
 });
 ```
 `svn update`

--- a/lib/svn.js
+++ b/lib/svn.js
@@ -25,7 +25,9 @@ Client.prototype.cmd = function(params, callback) {
     if (this.getOption('password') !== undefined) {
         params.push('--password', this.getOption('password'));
     }
-
+    if (this.getOption('noAuthCache') === true) {
+        params.push('--no-auth-cache');
+    }
     return Client.super_.prototype.cmd.call(this, params, callback);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svn-spawn",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "SVN access based on svn cli command",
   "main": "lib/svn.js",
   "scripts": {


### PR DESCRIPTION
Make the svn cli [--no-auth-cache option](http://svnbook.red-bean.com/en/1.6/svn.ref.svn.html) available when using svn-spawn.